### PR TITLE
version 3.0

### DIFF
--- a/src/main/java/de/johnnyjayjay/discord/api/command/Command.java
+++ b/src/main/java/de/johnnyjayjay/discord/api/command/Command.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
  * Describes an executed Command. <p>
  * Is used to parse a message which seems to be a command.
  * @author Johnny_JayJay
- * @version 2.9
+ * @version 3.0
  */
 public class Command {
 
@@ -14,8 +14,8 @@ public class Command {
     private String label;
     private String[] args;
 
-    Command(String raw, CommandSettings settings) {
-        var argsWithoutPrefix = raw.replaceFirst(settings.getPrefix(), "").split(" ");
+    Command(String raw, String prefix, CommandSettings settings) {
+        var argsWithoutPrefix = raw.replaceFirst(prefix, "").split(" ");
         var commandLabel = argsWithoutPrefix[0];
         var argList = Arrays.asList(argsWithoutPrefix);
         var args = argList.subList(1, argList.size()).toArray(new String[argList.size() - 1]);

--- a/src/main/java/de/johnnyjayjay/discord/api/command/CommandEvent.java
+++ b/src/main/java/de/johnnyjayjay/discord/api/command/CommandEvent.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 /**
  * Represents a command event. This is not much different from a GuildMessageReceivedEvent, though it gives access to the called command.
  * @author Johnny_JayJay
- * @version 2.9
+ * @version 3.0
  */
 public class CommandEvent extends GuildMessageReceivedEvent {
 

--- a/src/main/java/de/johnnyjayjay/discord/api/command/CommandListener.java
+++ b/src/main/java/de/johnnyjayjay/discord/api/command/CommandListener.java
@@ -19,25 +19,26 @@ class CommandListener extends ListenerAdapter {
     @Override
     public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
         var raw = event.getMessage().getContentRaw();
-        if (raw.startsWith(settings.getPrefix()) && !event.getAuthor().isBot()) {
-            Command cmd = new Command(raw, settings);
+        String prefix = settings.getPrefix(event.getGuild().getIdLong());
+        if (raw.startsWith(prefix) && !event.getAuthor().isBot()) {
+            Command cmd = new Command(raw, prefix, settings);
             if (cmd.getExecutor() != null) {
                 cmd.getExecutor().onCommand(new CommandEvent(event.getJDA(), event.getResponseNumber(), event.getMessage(), cmd),
                         event.getMember(), event.getChannel(), cmd.getArgs());
             } else if (settings.useHelpCommand() && settings.getHelpLabels().contains(cmd.getLabel())) {
-                this.sendInfo(event.getChannel(), cmd.getArgs());
+                this.sendInfo(event.getChannel(), prefix, cmd.getArgs());
             }
         }
     }
 
-    private void sendInfo(TextChannel channel, String[] args) {
+    private void sendInfo(TextChannel channel, String prefix, String[] args) {
         var builder = new EmbedBuilder().setTitle("Help");
         if (args.length == 0) {
             String helpLabels = format("[%s]", String.join("|", settings.getHelpLabels().toArray(new String[settings.getHelpLabels().size()])));
-            builder.appendDescription(format("To learn more about a specific command, just call `%s%s <label>`.\n", settings.getPrefix(), helpLabels))
+            builder.appendDescription(format("To learn more about a specific command, just call `%s%s <label>`.\n", prefix, helpLabels))
                     .appendDescription("The following commands are currently available:\n");
             var commandLabels = settings.getCommands().keySet().toArray(new String[settings.getCommands().keySet().size()]);
-            builder.addField("Commands", format("```\n%s%s```", settings.getPrefix(), String.join(format("\n%s", settings.getPrefix()), commandLabels)), false);
+            builder.addField("Commands", format("```\n%s%s```", prefix, String.join(format("\n%s", prefix), commandLabels)), false);
             channel.sendMessage(builder.build()).queue();
         } else if (args.length == 1 && settings.getCommands().containsKey(args[0])) {
             builder.appendDescription(format("Command Info for: `%s`\n\n", args[0]))
@@ -46,4 +47,3 @@ class CommandListener extends ListenerAdapter {
         }
     }
 }
-

--- a/src/main/java/de/johnnyjayjay/discord/api/command/CommandSetException.java
+++ b/src/main/java/de/johnnyjayjay/discord/api/command/CommandSetException.java
@@ -4,7 +4,7 @@ package de.johnnyjayjay.discord.api.command;
  * Exception that is thrown in case of any problems concerning the CommandSettings. <p>
  * CommandSetExceptions are RuntimeExceptions.
  * @author Johnny_JayJay
- * @version 2.9
+ * @version 3.0
  */
 public class CommandSetException extends RuntimeException {
     public CommandSetException(String msg) {

--- a/src/main/java/de/johnnyjayjay/discord/api/command/CommandSettings.java
+++ b/src/main/java/de/johnnyjayjay/discord/api/command/CommandSettings.java
@@ -12,51 +12,65 @@ import java.util.Set;
  * To use this API, create a new object of this class and add your command classes by using add(...)<p>
  * When you want your commands to become active, use activate()
  * @author Johnny_JayJay
- * @version 2.9
+ * @version 3.0
  */
 
 public class CommandSettings {
 
-    private String prefix;
+    // Regex which only matches valid prefixes
+    public static final String VALID_PREFIX = "([^\\\\+*^|$?])+";
+    // Regex which only matches valid command labels
+    public static final String VALID_LABEL = "([^\\s\\n\\t])+";
 
-    private Set<String> helpLabels;
-    private Map<String, ICommand> commands;
+    private String defaultPrefix;
+
+    private Set<String> helpLabels; // labels which trigger the auto-generated help command
+    private Map<Long, String> prefixMap; // Long: GuildID, String: prefix
+
+    private Map<String, ICommand> commands; // String: command label, ICommand: command class
 
     private JDA jda;
     private CommandListener listener;
 
-    private boolean used;
+    private boolean activated; // ...is this instance activated?
+
     private boolean useHelpCommand;
+    private boolean useCustomPrefixes;
 
 
     /**
      * This is the constructor.
      * The parameters are validated automatically. In case of any problems (if the prefix is empty), this will throw a CommandSetException.
      * @param jda Put your active JDA here. This is important for the activation of the CommandListener.
-     * @param prefix The String you will have to put before every command in order to get your command execution registered. This can later be changed.
+     * @param defaultPrefix The String you will have to put before every command in order to get your command execution registered. This can later be changed.
      * @param useHelpCommand Set this to true, if you want to use the auto-generated help command of this API. You can configure this by setting the help
      *                       labels with setHelpLabel(String...) and by overriding the method info() in your command classes.
+     * @param useCustomPrefixes Set this to true, if you want to have the possibility to add custom prefixes for each guild. If you didn't set a prefix for a guild, it will look
+     *                         for the default prefix.
      */
-    public CommandSettings(@Nonnull String prefix, @Nonnull JDA jda, boolean useHelpCommand) {
+    public CommandSettings(@Nonnull String defaultPrefix, @Nonnull JDA jda, boolean useHelpCommand, boolean useCustomPrefixes) {
         this.commands = new HashMap<>();
         this.listener = new CommandListener(this);
-        this.used = false;
-        this.setPrefix(prefix);
+        this.activated = false;
+        this.setDefaultPrefix(defaultPrefix);
         this.jda = jda;
         this.useHelpCommand = useHelpCommand;
-        if (useHelpCommand) {
-            this.helpLabels = new HashSet<>();
-        }
+        this.useCustomPrefixes = useCustomPrefixes;
+        this.helpLabels = new HashSet<>();
+        this.prefixMap = new HashMap<>();
     }
 
     /**
-     * Use this method to add help labels. This, of course, only makes sense if you instantiated this class with the parameter useHelpCommand as true.
+     * Use this method to add help labels. This will only work if you instantiated this class with the parameter useHelpCommand as true.
      * @param labels One or more labels which may later be called by members to list all commands or to show info about one specific command.
      * @return The current object. This is to use fluent interface.
      */
     public CommandSettings setHelpLabel(String... labels) {
-        for (String s : labels) {
-            helpLabels.add(s);
+        for (String label : labels) {
+            if (label.matches(VALID_LABEL))
+                helpLabels.add(label);
+            else
+                throw new CommandSetException("Help label cannot be empty, consist of multiple words or contain new lines!");
         }
         return this;
     }
@@ -65,16 +79,16 @@ public class CommandSettings {
      * Use this method to add commands from your project. Every command which is supposed to be active should be added by this.
      * <p>
      * The two parameters will be put in a HashMap which is used by the API to notice commands.
-     * @param label The label which describes your command, i.e. the string after the prefix [prefix][label]. If it is empty or consists of multiple words,
-     *              this will throw a CommandSetException.
+     * @param label The label which describes your command, i.e. the string after the prefix [prefix][label].
      * @param command An instance of your command class which implements ICommand.
      * @return The current object. This is to use fluent interface.
+     * @throws CommandSetException If the label is empty or consists of multiple words.
      */
     public CommandSettings put(@Nonnull ICommand command, @Nonnull String label) {
-        if (label.isEmpty() || label.contains(" "))
-            throw new CommandSetException("Command label cannot be empty or consist of multiple words");
-        else
+        if (label.matches(VALID_LABEL))
             commands.put(label, command);
+        else
+            throw new CommandSetException("Command label cannot be empty, consist of multiple words or contain new lines!");
 
         return this;
     }
@@ -87,9 +101,8 @@ public class CommandSettings {
      * @return The current object. This is to use fluent interface.
      */
     public CommandSettings put(@Nonnull ICommand command, @Nonnull String... labels) {
-        for (String label : labels) {
+        for (String label : labels)
             this.put(command, label);
-        }
         return this;
     }
 
@@ -99,47 +112,58 @@ public class CommandSettings {
      * @return true, if the label was successfully removed. false, if the given label doesn't exist.
      */
     public boolean remove(@Nonnull String label) {
-        boolean success = false;
-        if (commands.remove(label) != null)
-            success = true;
-        return success;
+        return commands.remove(label) != null;
     }
 
     /**
      * Use this method to remove more than one command at a time. <p>
      * @param labels One or more labels to remove
-     * @return true, if every label was successfully removed. false, if one of the given labels does not exist.
+     * @return true, if every label was successfully removed. false, if one of the given labels does not exist and thus was not removed.
      */
     public boolean remove(@Nonnull String... labels) {
         boolean success = true;
         for (String label : labels) {
-            if (!this.remove(label)) {
+            if (!this.remove(label))
                 success = false;
-            }
         }
         return success;
     }
 
     /**
-     * Use this method to set the prefix.
+     * Use this method to set the default prefix.
      * @param prefix The prefix to set. In case the given String is empty, this will throw a CommandSetException.
+     * @throws CommandSetException if the prefix is empty.
      */
-    public void setPrefix(@Nonnull String prefix) {
-        if (prefix.isEmpty())
-            throw new CommandSetException("Prefix cannot be empty");
+    public void setDefaultPrefix(@Nonnull String prefix) {
+        if (prefix.matches(VALID_PREFIX))
+            this.defaultPrefix = prefix;
         else
-            this.prefix = prefix;
+            throw new CommandSetException("Prefix cannot be empty or contain the characters +*^|$\\");
+    }
+
+    /**
+     * Use this method to add a custom command prefix to a guild. This will only work if you instantiated this class with useCustomPrefixes set to true.
+     * You can remove the custom prefix from a guild by setting its prefix to null.
+     * @param guildId The guild id as a long.
+     * @param prefix The prefix to be set.
+     * @throws CommandSetException if a non-null prefix is empty.
+     */
+    public void setCustomPrefix(long guildId, String prefix) {
+        if (prefix != null && !prefix.matches(VALID_PREFIX))
+            throw new CommandSetException("Prefix cannot be empty or contain the characters +*^|$\\");
+        prefixMap.put(guildId, prefix);
     }
 
     /**
      * Sets the prefix and the command HashMap for the rest of the API. This is the last method to call when having finished setting up your commands.<p>
      * Note that activating multiple CommandSettings may cause problems. You can do this to use multiple prefixes, but it is not recommended.<p>
      * This method is important to call because otherwise no command will be registered by the internal command listener.
+     * @throws CommandSetException if you already activated this instance.
      */
     public void activate() {
-        if (!used) {
+        if (!activated) {
             jda.addEventListener(listener);
-            used = true;
+            activated = true;
         } else
             throw new CommandSetException("CommandSettings already activated!");
     }
@@ -147,13 +171,31 @@ public class CommandSettings {
     /**
      * Deactivates the current CommandSettings by removing the command listener from jda.
      * The CommandSettings can be activated again by using activate().
+     * @throws CommandSetException if you either did not activate this instance or already deactivated it.
      */
     public void deactivate() {
-        if (used) {
+        if (activated) {
             jda.removeEventListener(listener);
-            used = false;
+            activated = false;
         } else
             throw new CommandSetException("CommandSettings weren't activated yet and can therefore not be deactivated!");
+    }
+
+    /**
+     * Use this method to get the prefix for a specific guild.
+     * @param guildId The id of the guild to check.
+     * @return the default prefix, if there is no custom prefix set for the given guild id. Otherwise, it returns the custom prefix.
+     */
+    public String getPrefix(long guildId) {
+        return (useCustomPrefixes && prefixMap.get(guildId) != null) ? prefixMap.get(guildId) : defaultPrefix;
+    }
+
+    /**
+     * Use this method to get the default prefix.
+     * @return default prefix set in the constructor or the method setDefaultPrefix(String).
+     */
+    public String getPrefix() {
+        return defaultPrefix;
     }
 
     protected Set<String> getHelpLabels() {
@@ -164,13 +206,8 @@ public class CommandSettings {
         return useHelpCommand;
     }
 
-    protected String getPrefix() {
-        return prefix;
-    }
-
     protected Map<String, ICommand> getCommands() {
         return commands;
     }
-
 
 }

--- a/src/main/java/de/johnnyjayjay/discord/api/command/ICommand.java
+++ b/src/main/java/de/johnnyjayjay/discord/api/command/ICommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.core.entities.TextChannel;
  * An interface used to describe a command class.
  * In order to use this API, every class which is supposed to execute commands must implement this interface.
  * @author Johnny_JayJay
- * @version 2.9
+ * @version 3.0
  */
 
 public interface ICommand {


### PR DESCRIPTION
New features:
- added possibility to configure custom prefixes for each guild
- you can get the prefix with `CommandSettings#getPrefix()` or `CommandSettings#getPrefix(long)`
- fixed several bugs concerning patterns. it is no longer possible to set the prefix to a value which contains metacharacters, because that caused api-based exceptions. Instead, a CommandSetException will now be thrown in case of unallowed prefixes.
- this can be avoided by matching the given prefix with `CommandSettings.VALID_PREFIX`. Same goes for labels with `CommandSettings.VALID_LABEL`.
- cleaned the code in general.